### PR TITLE
operand type clash issue fixed (#120)

### DIFF
--- a/SQLWATCHDB/dbo/Procedures/usp_sqlwatch_logger_agent_job_history.sql
+++ b/SQLWATCHDB/dbo/Procedures/usp_sqlwatch_logger_agent_job_history.sql
@@ -40,7 +40,7 @@ from msdb.dbo.sysjobhistory jh
 		and js.step_name = convert(nvarchar(128),jh.step_name) collate database_default
 
 	/* make sure we are only getting new records from msdb history 
-	   need to check performnace over long time !!! */
+	   need to check performance over long time !!! */
 	left join [dbo].[sqlwatch_logger_agent_job_history] sh
 		on sh.sql_instance = mj.sql_instance
 		and sh.[sysjobhistory_instance_id] = jh.instance_id

--- a/SQLWATCHDB/dbo/Procedures/usp_sqlwatch_logger_index_histogram.sql
+++ b/SQLWATCHDB/dbo/Procedures/usp_sqlwatch_logger_index_histogram.sql
@@ -1,4 +1,5 @@
-﻿CREATE PROCEDURE [dbo].[usp_sqlwatch_logger_index_histogram]
+CREATE PROCEDURE [dbo].[usp_sqlwatch_logger_index_histogram]
+
 as
 
 set xact_abort on
@@ -19,8 +20,10 @@ declare @sqlwatch_table_id int
 declare @sqlwatch_index_id int
 
 declare @indextype as table (
-	is_index_hierarchical bit
+	is_index_hierarchical bit,
+	is_index_timestamp bit
 )
+
 
 create table #stats_hierarchical (
 	[database_name] sysname default 'fe92qw0fa_dummy',
@@ -28,6 +31,32 @@ create table #stats_hierarchical (
 	index_name sysname default 'fe92qw0fa_dummy',
 	index_id int,
 	RANGE_HI_KEY hierarchyid,
+	RANGE_ROWS real,
+	EQ_ROWS real,
+	DISTINCT_RANGE_ROWS real,
+	AVG_RANGE_ROWS real,
+	[collection_time] datetime,
+	[sqlwatch_database_id] smallint,
+	[sqlwatch_table_id] int,
+	[sqlwatch_index_id] int
+)
+
+/* new temp table because of  https://github.com/marcingminski/sqlwatch/issues/119 */ 
+create table #stats_timestamp (
+	[database_name] sysname default 'fe92qw0fa_dummy',
+	[object_name] sysname default 'fe92qw0fa_dummy',
+	index_name sysname default 'fe92qw0fa_dummy',
+	index_id int,
+	/*
+		timestamp is a rowversion column - a binary "counter" to identify that the row has been modified. 
+		it is unlikely to have index or/and stats on the rowversion column but we have seen it happen. (yay vendor apps!)
+		so we have to be able to handle it. 		
+		Anyway, timestamp (aka rowversion) will implicitly convert to varchar and datetime.
+		when converted to varchar the value will be empty string, and when converted to datetime it will simply add the counter value to 1900-01-01
+		and will show relatively random date. I don't either will be of any use and I'd be actually tempted to just not collect any stats from indexes on these columns 
+		but happy to wait for community advice and expertise. 
+	*/
+	RANGE_HI_KEY datetime, 
 	RANGE_ROWS real,
 	EQ_ROWS real,
 	DISTINCT_RANGE_ROWS real,
@@ -55,6 +84,7 @@ create table #stats (
 )
 
 declare @is_index_hierarchical bit
+declare @is_index_timestamp bit  
 
 set @snapshot_type = 15
 
@@ -105,8 +135,12 @@ into @database_name, @object_name, @index_name, @index_id, @sqlwatch_database_id
 while @@FETCH_STATUS = 0
 	begin
 		delete from @indextype
+		select @is_index_hierarchical = 0, @is_index_timestamp = 0
+
 		set @sql = 'use [' + @database_name + ']; 
-			select case when tp.name = ''hierarchyid'' then 1 else 0 end
+			select
+				is_index_hierarchical = case when tp.name = ''hierarchyid'' then 1 else 0 end,
+				is_index_timestamp = case when tp.name = ''timestamp'' then 1 else 0 end
 			from sys.schemas s
 			inner join sys.tables t 
 				on s.schema_id = t.schema_id
@@ -126,11 +160,13 @@ while @@FETCH_STATUS = 0
 				and tp.user_type_id = c.user_type_id
 			where i.name = ''' + @index_name + '''
 			and s.name + ''.'' + t.name = ''' + @object_name + ''''
-		insert into @indextype(is_index_hierarchical)
+		insert into @indextype(is_index_hierarchical, is_index_timestamp)
 		exec (@sql)
 
-		select @is_index_hierarchical = is_index_hierarchical from @indextype
-		set @is_index_hierarchical  = isnull(@is_index_hierarchical ,0)
+		select 
+			@is_index_hierarchical = is_index_hierarchical,
+			@is_index_timestamp = is_index_timestamp
+		from @indextype
 
 
 		--set @object_name = object_schema_name(@object_id) + '.' + object_name(@object_id)
@@ -153,6 +189,22 @@ if exists (
 				exec (@sql)
 
 				update #stats_hierarchical
+					set [database_name] = @database_name
+						, [object_name] = @object_name
+						, index_name = @index_name
+						, index_id = @index_id
+						, [collection_time] = getutcdate()
+						, [sqlwatch_database_id] = @sqlwatch_database_id
+						, [sqlwatch_table_id] = @sqlwatch_table_id
+						, [sqlwatch_index_id] = @sqlwatch_index_id
+				where index_name = 'fe92qw0fa_dummy'
+			end
+		else if @is_index_timestamp = 1
+			begin
+				insert into #stats_timestamp (RANGE_HI_KEY,RANGE_ROWS,EQ_ROWS,DISTINCT_RANGE_ROWS,AVG_RANGE_ROWS)
+				exec (@sql)
+
+				update #stats_timestamp
 					set [database_name] = @database_name
 						, [object_name] = @object_name
 						, index_name = @index_name
@@ -226,5 +278,24 @@ deallocate c_index
 		[snapshot_type_id] = @snapshot_type,
 		[collection_time]
 	from #stats_hierarchical st
+
+	insert into [dbo].[sqlwatch_logger_index_usage_stats_histogram](
+			[sqlwatch_database_id], [sqlwatch_table_id], [sqlwatch_index_id],
+		RANGE_HI_KEY, RANGE_ROWS, EQ_ROWS, DISTINCT_RANGE_ROWS, AVG_RANGE_ROWS,
+		[snapshot_time], [snapshot_type_id], [collection_time])
+	select
+		st.[sqlwatch_database_id],
+		st.[sqlwatch_table_id],
+		st.[sqlwatch_index_id],
+		convert(nvarchar(max),st.RANGE_HI_KEY),
+		RANGE_ROWS = convert(real,st.RANGE_ROWS),
+		EQ_ROWS = convert(real,st.EQ_ROWS),
+		DISTINCT_RANGE_ROWS = convert(real,st.DISTINCT_RANGE_ROWS),
+		AVG_RANGE_ROWS = convert(real,st.AVG_RANGE_ROWS),
+		[snapshot_time] = @snapshot_time,
+		[snapshot_type_id] = @snapshot_type,
+		[collection_time]
+	from #stats_timestamp st
+
 
 commit tran


### PR DESCRIPTION
* just little typo fix

* modified usp_sqlwatch_logger_index_histogram

* Fixes #119

1. Added comments
2. Removed @indextype2 temp table, and moved is_index_timestamp to @indextype. This way we only have table
3. Analogically, also removed the second check and merged with the already existing check that now returns two columns instead of just one. This way we only run one query instead of two.
4. Change case to lower for consistency